### PR TITLE
Fix for 64 bit Python versions

### DIFF
--- a/XChat_AES.py
+++ b/XChat_AES.py
@@ -200,7 +200,7 @@ def blowcrypt_b64decode(s):
             right |= B64.index(p) << (i * 6)
         for i, p in enumerate(s[6:12]):
             left |= B64.index(p) << (i * 6)
-        res += struct.pack('>LL', left, right)
+        res += struct.pack('>LL', left & 0xFFFFFFFF, right & 0xFFFFFFFF)
         s = s[12:]
     return res
 


### PR DESCRIPTION
On 64 bit versions of Python, integers should be padded to the lower 32 bits for `struct.pack` not to die on `L` (32 bit).
